### PR TITLE
Deployment support

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -6,7 +6,7 @@ echo "What do you want your project to be called?"
 read project_name
 
 # ensure the project name has no special characters
-project_name=$(echo $project_name | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
+project_name=$(echo "$project_name" | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
 
 # ask them to confirm the project name
 read -p "The project name is \"$project_name\". Would you like to proceed? (y/n) " -n 1 -r
@@ -53,8 +53,8 @@ then
     fi
 fi
 
-mkdir $project_name
-cd $project_name
+mkdir "$project_name"
+cd "$project_name" || exit
 
 git init
 git pull git@github.com:mobify/astro-scaffold.git --depth 1
@@ -88,7 +88,7 @@ while true; do
         echo "Done"
         break
     else
-        echo $FOLDER
+        echo "$FOLDER"
         mv -vf "$FOLDER" "${FOLDER/scaffold/$project_name}"
     fi
 done

--- a/generator.sh
+++ b/generator.sh
@@ -28,11 +28,55 @@ read hostname
 echo "What Bundle Identifier would you like to use? (ex: com.yourcompany.yourapp)"
 read bundle_identifier
 
+ios_ci_support=0
+android_ci_support=0
+
+read -p "Do you want CircleCI support?" -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    # if yes, inform user of Circle setup document
+    read -p "Do you want iOS CI support?" -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        echo "Please see the main README about setting up iOS CI support"
+        ios_ci_support=1
+    fi
+
+    read -p "Do you want Android CI support?" -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+    echo "Please see the main README about setting up Android CI support"
+        android_ci_support=1
+    fi
+fi
+
 mkdir $project_name
 cd $project_name
 
 git init
 git pull git@github.com:mobify/astro-scaffold.git --depth 1
+
+if [[ "$ios_ci_support" -ne 1 && "$android_ci_support" -ne 1 ]]; then
+    rm -rf circle.yml
+    rm -rf circle
+else
+    if [ "$ios_ci_support" -ne 1 ]; then
+        rm circle/add-ios-keys.sh
+        rm circle/build-and-upload-ios.sh
+        rm circle/remove-ios-keys.sh
+        rm circle/config/mobify-qa-ios
+        sed -i '' '/^## IOS_BEGIN$/,/^## IOS_END$/d' circle.yml
+    fi
+    if [ "$android_ci_support" -ne 1 ]; then
+        rm circle/build-and-upload-android.sh
+        rm circle/install-android-dependencies.sh
+        rm circle/config/mobify-qa-android
+        sed -i '' '/^## ANDROID_BEGIN$/,/^## ANDROID_END$/d' circle.yml
+    fi
+fi
 
 # replace scaffold in the names of different files and folders with $project_name
 while true; do

--- a/generator.sh
+++ b/generator.sh
@@ -31,12 +31,12 @@ read bundle_identifier
 ios_ci_support=0
 android_ci_support=0
 
-read -p "Do you want CircleCI support?" -n 1 -r
+read -p "Do you want CircleCI support? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
     # if yes, inform user of Circle setup document
-    read -p "Do you want iOS CI support?" -n 1 -r
+    read -p "Do you want iOS CI support? (y/n) " -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
@@ -44,7 +44,7 @@ then
         ios_ci_support=1
     fi
 
-    read -p "Do you want Android CI support?" -n 1 -r
+    read -p "Do you want Android CI support? (y/n) " -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]
     then

--- a/generator.sh
+++ b/generator.sh
@@ -69,6 +69,8 @@ else
         rm circle/remove-ios-keys.sh
         rm circle/config/mobify-qa-ios
         sed -i '' '/^## IOS_BEGIN$/,/^## IOS_END$/d' circle.yml
+        rm -rf circle/certificates
+        rm -rf circle/provisioning-profiles
     fi
     if [ "$android_ci_support" -ne 1 ]; then
         rm circle/build-and-upload-android.sh

--- a/generator.sh
+++ b/generator.sh
@@ -25,7 +25,7 @@ echo "What host would you like to override for deep linking into your Android ap
 read hostname
 
 # ask for the bundle identifier
-echo "What Bundle Identifier would you like to use? (ex: com.yourcompany.yourapp)"
+echo "What Bundle Identifier would you like to use? (ex: com.yourcompany.yourapp - if you want Mobify projects to work out of the box with hockeyapp, it must start with "com.mobify.")"
 read bundle_identifier
 
 ios_ci_support=0

--- a/generator.sh
+++ b/generator.sh
@@ -24,33 +24,28 @@ read app_scheme
 echo "What host would you like to override for deep linking into your Android app? (ex: www.example.com)"
 read hostname
 
-# ask for the bundle identifier 
+# ask for the bundle identifier
 echo "What Bundle Identifier would you like to use? (ex: com.yourcompany.yourapp)"
 read bundle_identifier
 
 ios_ci_support=0
 android_ci_support=0
 
-read -p "Do you want CircleCI support? (y/n) " -n 1 -r
+# if yes, inform user of Circle setup document
+read -p "Do you want iOS CI support? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    # if yes, inform user of Circle setup document
-    read -p "Do you want iOS CI support? (y/n) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]
-    then
-        echo "Please see the main README about setting up iOS CI support"
-        ios_ci_support=1
-    fi
+    echo "Please see the main README about setting up iOS CI support"
+    ios_ci_support=1
+fi
 
-    read -p "Do you want Android CI support? (y/n) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]
-    then
-        echo "Please see the main README about setting up Android CI support"
-        android_ci_support=1
-    fi
+read -p "Do you want Android CI support? (y/n) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Please see the main README about setting up Android CI support"
+    android_ci_support=1
 fi
 
 mkdir "$project_name"

--- a/generator.sh
+++ b/generator.sh
@@ -75,6 +75,7 @@ else
     if [ "$android_ci_support" -ne 1 ]; then
         rm circle/build-and-upload-android.sh
         rm circle/install-android-dependencies.sh
+        rm circle/wait-for-emulator-android.sh
         rm circle/config/mobify-qa-android
         sed -i '' '/^## ANDROID_BEGIN$/,/^## ANDROID_END$/d' circle.yml
     fi

--- a/generator.sh
+++ b/generator.sh
@@ -24,8 +24,8 @@ read app_scheme
 echo "What host would you like to override for deep linking into your Android app? (ex: www.example.com)"
 read hostname
 
-# ask for the bundle identifier
-echo "What Bundle Identifier would you like to use? (ex: com.yourcompany.yourapp - if you want Mobify projects to work out of the box with hockeyapp, it must start with "com.mobify.")"
+# ask for the bundle identifier / package name
+echo "What Bundle Identifier (iOS) / Package Name (Android) would you like to use? (ex: com.yourcompany.yourapp - if you want Mobify projects to work out of the box with hockeyapp, it must start with "com.mobify.")"
 read bundle_identifier
 
 ios_ci_support=0

--- a/generator.sh
+++ b/generator.sh
@@ -48,7 +48,7 @@ then
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
-    echo "Please see the main README about setting up Android CI support"
+        echo "Please see the main README about setting up Android CI support"
         android_ci_support=1
     fi
 fi


### PR DESCRIPTION
Support for configuring deployment config/scripts in astro-scaffold

Status: **Opened for review**

Reviewers: @jansepar @jeremywiebe @jvaill @jvoll @lizcross
JIRA: **https://mobify.atlassian.net/browse/HYB-372**
Linked PRs: **https://github.com/mobify/astro-scaffold/pull/18**
## Changes
- Adds prompts to include CircleCI test and deployment scripts
- You can choose for iOS and/or Android
## How to test-drive this PR
- Temporarily change the script to point to pulling down https://github.com/mobify/astro-scaffold/tree/ci-integration (you can change the git pull line to: `git pull git@github.com:mobify/astro-scaffold.git ci-integration:ci-integration --depth 1`
- (necessary corresponding PRs)
## TODOS:
- [x] Change works in both Android and iOS
