### PR TITLE
Add reasoning for generator-astro vs. astro-generator naming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Or if you don't have the repo checked out:
 ```sh
 bash <(curl -fsS https://raw.githubusercontent.com/mobify/generator-astro/master/generator.sh)
 ```
+
+Why `generator-astro` and not `astro-generator`
+-----------------------------------------------
+
+Initially we envisioned using (Yeoman)[http://yeoman.io/] for the generator. Yeoman generators are prefixed with `generator-` and so we followed that convention. 


### PR DESCRIPTION
Add a quick note to README.md explaining the repo naming choice.
