### PR TITLE
Astro on npm

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,127 @@
+This License Agreement (“Agreement”) governs use of the Product (defined below). This Agreement
+limits and excludes warranties and remedies regarding the Product, exempts Mobify (defined below)
+and other persons from liability or limits their liability, specifies the jurisdiction for
+resolution of disputes, and contains other important provisions that you should read. Through your
+license, you acknowledge and signify your acceptance and agreement, as the Licensee (defined below),
+without limitation or qualification, to be bound by this Agreement, and you represent and warrant
+that you have the legal authority to accept and agree to this Agreement. If Licensee does not agree
+with each provision of this Agreement, or you are not authorized to agree to this Agreement on
+behalf of Licensee, then neither you nor any other person on behalf of Licensee may use the Product.
+
+This Agreement governs the relationship between the licensed user of the software product described
+herein (“Licensee”) and Mobify Research and Development Inc. having a principle place of business at
+3rd Floor, 948 Homer St. Vancouver BC, Canada, V6B 2W7 (“Mobify”). This Agreement witnesses that,
+for good and valuable consideration, the receipt and sufficiency of which is hereby acknowledged by
+both parties, the parties hereby agree as follows:
+
+1. The following are defined terms used in the Agreement: (i) “Fees” means all applicable licensing
+fees for the use of the Product; (ii) “Product” means the software product licensed herein to the
+Licensee for the sole purpose or running Licensee’s authorized website(s), application(s) and
+server(s) pursuant to the terms and conditions as set of herein with respect to an authorized
+limited trial or paid subscription to Mobify Cloud http://cloud.mobify.com; and (iii) “Proprietary
+Information”  means the Product and related documentation, and all current and future product and
+pricing information, business practices, maintenance procedures, services and support, method,
+strategies, plans and information identified or reasonably identifiable as confidential and
+proprietary.
+
+2. Subject to the terms and conditions of this Agreement, Mobify grants to the Licensee a personal,
+time-based, non-exclusive, nontransferable, non-sublicensable right to access and use the Product in
+exchange for payment of the Fees. Except only for the limited right granted in the preceding
+sentence, Mobify reserves title, ownership and all rights and interests, including intellectual
+property rights and trade secrets, in the Product. Licensee will not directly or indirectly resell
+or grant access to the Product and will not attempt to access, download, copy, decompile, revise,
+engineer, modify, or derive source code or other elements of the Product, nor prepare translations
+or derivative works based upon same, distribute, subscribe, rent, lease, sell or otherwise
+commercially exploit the Product. Any other use of the Product by any other entity is forbidden and
+a violation of this Agreement, including use of the Product by any of Licensee’s corporate
+affiliates or subsidiaries.
+
+3. The Product and all related intellectual property rights thereto are the sole and exclusive
+property of Mobify. All right, title and interest in and to the Product, any modifications,
+improvements, translations, or derivatives thereof, even if unauthorized, and all applicable rights
+in patents, copyrights, trade secrets, trademarks and all intellectual property rights in the
+Product remain exclusively with Mobify, including any modifications or improvements made thereto at
+the suggestion of, or with input from, Licensee. The Product is valuable, proprietary, and unique,
+and Licensee agrees to be bound by and observe the proprietary nature of the Product. All rights not
+granted to Licensee in this Agreement are reserved to Mobify. No ownership of the Product passes to
+Licensee. Mobify may make changes to the Product at any time without notice. Except as otherwise
+expressly provided, Mobify grants no express or implied right under Mobify patents, copyrights,
+trademarks, or other intellectual property rights.
+
+4. Licensee warrants that it has inspected the Product and has found it satisfactory, adequate and
+fit for its purpose and that Licensee’s use of the Product does not infringement any third party
+agreement to which the Licensee is a party.  Mobify warrants that any Proprietary Information
+provided by Mobify pursuant to this Agreement and the Product do not infringe, violate or
+misappropriate the intellectual property rights of any third parties. Subject to preceding sentence,
+the Product is provided to the Licensee without any warranty and Mobify hereby disclaims any
+warranty that the Product shall be error free, without defects or code which may cause damage to
+Licensee’s systems or to Licensee, and that the Product shall be functional. Licensee shall be
+solely liable to any damage, defect or loss incurred as a result of operating the Product and
+assumes all risks associated with using the Product. Further, Licensee acknowledges and agrees that
+Mobify shall not in any way be responsible for any claim arising from, connected with or relating
+to: (i) use of Product; (ii) use of the Product with any service, technology, software, hardware,
+data or other materials, whether intended or not intended, to be used with the Product; (iii) a
+wrongful act or omission by Licensee or any person for whom Licensee is responsible; and (iv) a
+claim of infringement or misappropriation of intellectual property rights made by a person (commonly
+known as a “patent troll”, a “patent assertion entity” or a “non-practicing entity”) who is not
+actually using in practice the infringed or misappropriated intellectual property rights. Licensee
+further acknowledges and agrees that Mobify is not responsible for the function of the Internet and
+that Mobify disclaims any liability for deficiencies in performance caused by Internet latency,
+downtime, etc.  Mobify does not warrant that access to the Product will be uninterrupted or
+error-free.  Mobify shall not be liable for data system failure or damage to Licensee’s internal
+system as a result of interaction between the Product and Licensee’s internal systems, unless the
+failure or damage is clearly the result of a defect in the Product.  Mobify may, in its discretion,
+change the functionality or operation of the Product from time to time without any notice or
+liability to Licensee or any other person, provided that any change will not materially adversely
+affect the functionality or operation of the     Product that is relevant to Licensee’s actual use
+of the Product. EACH PARTY ACKNOWLEDGES THAT THE OTHER PARTY MAKES NO REPRESENTATIONS, WARRANTIES OR
+CONDITIONS, INCLUDING ALL IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE, OR AGREEMENTS RELATED TO THE SUBJECT MATTER HEREOF, THAT ARE NOT EXPRESSLY
+PROVIDED FOR IN THIS AGREEMENT.
+
+5. Licensee will defend Mobify against any claim, demand, suit or proceeding made or brought against
+Mobify by a third party resulting from the use of the Product by Licensee, any material supplied by
+Licensee to Mobify that infringes on the proprietary rights of a third party, or otherwise
+constitutes a copyright infringement and any violation of any law arising out of or relating to use
+of the Product and will indemnify Mobify from any damages, attorney fees and costs awarded against
+Mobify. IN NO EVENT WILL SHALL MOBIFY HAVE ANY LIABILITY FOR ANY DIRECT DAMAGES, ANY LOST PROFITS,
+REVENUES OR INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, COVER OR PUNITIVE DAMAGES, WHETHER AN
+ACTION IS IN CONTRACT OR TORT AND REGARDLESS OF THE THEORY OF LIABILITY, EVEN IF MOBIFY HAS BEEN
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. THE FOREGOING DISCLAIMER WILL NOT APPLY TO THE EXTENT
+PROHIBITED BY LAW.
+
+6. This Agreement shall terminate (i) upon notice from Mobify; (ii) upon Licensee becoming the
+subject of a voluntary or involuntary petition in bankruptcy or any voluntary or involuntary
+proceeding relating to insolvency, receivership, liquidation or composition for the benefit of
+creditors; and (iii) where Licensee materially breaches this Agreement or the law. Upon the expiry
+or termination of the Agreement: (i) all licenses will immediately cease; (ii) Licensee will return
+to Mobify or destroy all Proprietary Information belonging to Mobify; and (ii) all Fees will be
+payable in full up to the effective date of expiry or termination.
+
+7. Mobify may provide Licensee, from time to time, with upgrades, updates or fixes in its sole and
+exclusive discretion. Licensee agrees to keep the Product up-to-date and install all relevant
+updates and fixes, and may, at his sole discretion, purchase upgrades, according to the rates set by
+Mobify. For the purposes of this Agreement: (i) an upgrade shall be a material amendment in the
+Product, which contains new features and or major performance improvements and shall be marked as a
+new version number; (ii) an update shall be a minor amendment in the Product, which may contain new
+features or minor improvements and shall be marked as a new sub-version number; and (iii) a fix
+shall be a minor amendment in the Product, intended to remove bugs or alter minor features which
+impair the Products functionality and shall be marked as a new sub-sub-version number.  Any support,
+updates and maintenance are governed by the terms and conditions set out under the Mobify service
+agreement for limited trial or paid subscription to Mobify Cloud.
+
+8. This Agreement is the entire agreement between Mobify and Licensee regarding the Product and
+supersedes all prior and contemporaneous agreements, proposals or representations, written or oral,
+concerning its subject matter. No modification, amendment, or waiver of any provision of this
+Agreement will be effective unless in writing and signed by the party against whom the modification,
+amendment or waiver is to be asserted. No failure or delay by either party in exercising any right
+under this Agreement will constitute a waiver of that right. If any provision of this Agreement is
+held by a court of competent jurisdiction to be contrary to law, the provision will be deemed null
+and void, and the remaining provisions of this Agreement will remain in effect. Disputes arising out
+of or relating to this Agreement shall be governed by and interpreted in accordance with the laws of
+British Columbia and adjudicated in the courts of British Columbia.  The parties are independent
+contractors. This Agreement does not create a licensee and licensor relationship, sublicensee and
+sublicensor relationship, partnership, franchise, joint venture, agency, fiduciary or employment
+relationship between the parties. This Agreement may be executed in counterparts, any one of which
+may be a fax, PDF or other form of electronic copy, and each of which shall be an original
+instrument, but all of which shall constitute one and the same agreement.

--- a/generator.sh
+++ b/generator.sh
@@ -37,7 +37,7 @@ mkdir $project_name
 cd $project_name || exit
 
 git init
-git pull git@github.com:mobify/astro-scaffold.git 0.6.0 --depth 1
+git pull git@github.com:mobify/astro-scaffold.git astro-on-npm --depth 1
 
 if [[ $ios_ci_support -ne 1 && $android_ci_support -ne 1 ]]; then
     rm -rf circle.yml
@@ -86,15 +86,6 @@ egrep -lR "scaffold" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/scaffold/$proj
 # Update symlink to "scaffold-www" folder in android/assets
 ln -sfn ../../../../../app/$project_name-www/ android/$project_name/src/main/assets/$project_name-www
 
-# Grab the commit ref for that submodule.
-commit=$(git ls-tree master | grep astro | awk '{ print $3; }')
-
-# Blow away the astro submodule, and the history, then re-initialize git
-rm -rf .git astro
 git init
-git submodule add --force git@github.com:mobify/astro.git astro
-cd astro
-git checkout $commit
-cd ..
 git add .
 git commit -am 'Your first Astro commit - AMAZING! 🌟 👍🏽'

--- a/generator.sh
+++ b/generator.sh
@@ -7,9 +7,8 @@ if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
     exit 1
 fi
 
-# TODO: only download if necessary
-curl -s -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/mobify/astro-scaffold/contents/LICENSE
-less LICENSE
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+less $script_dir/LICENSE
 
 read -p"--> I have read, understand, and accept the terms and conditions stated in the license above. (y/n) " -n 1 -r
 echo

--- a/generator.sh
+++ b/generator.sh
@@ -89,3 +89,4 @@ ln -sfn ../../../../../app/$project_name-www/ android/$project_name/src/main/ass
 git init
 git add .
 git commit -am 'Your first Astro commit - AMAZING! 🌟 👍🏽'
+npm install

--- a/generator.sh
+++ b/generator.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -o pipefail
 
+read -p"--> We have a license you must read and agree to. Read license? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
+    exit 1
+fi
+
+# TODO: only download if necessary
+curl -s -H 'Accept: application/vnd.github.v3.raw' -O -L https://api.github.com/repos/mobify/astro-scaffold/contents/LICENSE
+less LICENSE
+
+read -p"--> I have read, understand, and accept the terms and conditions stated in the license above. (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
+    exit 1
+fi
 
 read -p'--> What is the name of your project? ' project_name
 # $project_name must not contain special characters.

--- a/generator.sh
+++ b/generator.sh
@@ -51,7 +51,7 @@ mkdir $project_name
 cd $project_name || exit
 
 git init
-git pull git@github.com:mobify/astro-scaffold.git astro-on-npm --depth 1
+git pull git@github.com:mobify/astro-scaffold.git 0.7.0 --depth 1
 
 if [[ $ios_ci_support -ne 1 && $android_ci_support -ne 1 ]]; then
     rm -rf circle.yml


### PR DESCRIPTION
Reviewers: Anyone on Astro!
JIRA: https://mobify.atlassian.net/browse/HYB-646
Linked PRs: https://github.com/mobify/astro/pull/399, https://github.com/mobify/astro-scaffold/pull/53
## Changes
- Brings the Astro SDK dependancy through npm rather than through git submodules
## How to test-drive this PR
- Run the generator and ensure the generator ios and android apps work.
## TODOS:
- [x] Prompt the generator to show the license
- [x] Change works in both Android and iOS
- [x] Update git pull depth 1 statement to point to 0.7.0 astro-scaffold tag
