### PR TITLE
Download scaffold from release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+v0.7.1
+======
+
+- Change `generator.sh` to download the scaffold from the release instead of `git clone`ing it.

--- a/generator.sh
+++ b/generator.sh
@@ -62,21 +62,17 @@ mkdir "$project_dir"
 cd "$project_dir" || exit
 git init
 
-set -x
 # Download the scaffold and copy it into the project directory
 WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
 echo "Working directory: $WORKING_DIR"
 trap 'rm -rf "$WORKING_DIR"' EXIT
+
 curl --progress-bar -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
-ls "$WORKING_DIR"
 cd $WORKING_DIR || exit
-unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
-ls "$WORKING_DIR"
-cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION" "$project_dir"
-ls "$project_dir"
+unzip -q "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
+cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION/" "$project_dir"
 
 cd "$project_dir"
-set +x
 
 # Set up CI support
 if [[ $ios_ci_support -ne 1 && $android_ci_support -ne 1 ]]; then

--- a/generator.sh
+++ b/generator.sh
@@ -26,7 +26,7 @@ fi
 
 read -p'--> What is the name of your project? ' project_name
 # $project_name must not contain special characters.
-project_name=$(echo $project_name | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
+project_name=$(echo "$project_name" | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
 
 read -p"--> Continue with the project name '$project_name'? (y/n) " -n 1 -r
 echo
@@ -34,8 +34,11 @@ if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
     exit 1
 fi
 
-read -p'--> On iOS, which app scheme do you want for deep linking? (eg. mobify) ' app_scheme
+# Currently we do nothing with 'app_scheme' so we won't prompt for it right now
+# read -p'--> On iOS, which app scheme do you want for deep linking? (eg. mobify) ' app_scheme
+
 read -p'--> On Android, which host would you like to use for deep linking? (eg. www.mobify.com) ' hostname
+
 read -p"--> Which iOS Bundle Identifier and Android Package Name would you like to use? Begin with 'com.mobify.' to use HockeyApp. (eg. com.mobify.app) " bundle_identifier
 
 ios_ci_support=0
@@ -67,11 +70,11 @@ WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
 trap 'rm -rf "$WORKING_DIR"' EXIT
 
 curl --progress-bar -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
-cd $WORKING_DIR || exit
+cd "$WORKING_DIR" || exit
 unzip -q "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
 cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION/" "$project_dir"
 
-cd "$project_dir"
+cd "$project_dir" || exit
 
 # Set up CI support
 if [[ $ios_ci_support -ne 1 && $android_ci_support -ne 1 ]]; then
@@ -119,7 +122,7 @@ egrep -lR "android:host=\"www.mobify.com\"" . | tr '\n' '\0' | xargs -0 -n1 sed 
 egrep -lR "scaffold" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/scaffold/$project_name/g" 2>/dev/null
 
 # Update symlink to "scaffold-www" folder in android/assets
-ln -sfn ../../../../../app/$project_name-www/ android/$project_name/src/main/assets/$project_name-www
+ln -sfn ../../../../../app/"$project_name"-www/ android/"$project_name"/src/main/assets/"$project_name"-www
 
 git init
 git add .

--- a/generator.sh
+++ b/generator.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -o pipefail
 
-MYDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-ROOT=$MYDIR
+MYDIR=$(pwd)
+ROOT=$MYDIR # In some scripts ROOT != MYDIR
 
 ASTRO_VERSION=0.7.0
 SCAFFOLD_VERSION=$ASTRO_VERSION
@@ -44,14 +44,14 @@ android_ci_support=0
 read -p'--> On iOS, do you want continuous integration? (y/n) ' -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
-    echo '        ↳ To setup iOS continuous integration, see README.md.'
+    echo '    ↳ To setup iOS continuous integration, see README.md.'
     ios_ci_support=1
 fi
 
 read -p "--> On Android, do you want continuous integration? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
-    echo '       ↳ To setup Android continuous integration, see README.md.'
+    echo '   ↳ To setup Android continuous integration, see README.md.'
     android_ci_support=1
 fi
 

--- a/generator.sh
+++ b/generator.sh
@@ -51,7 +51,7 @@ fi
 read -p "--> On Android, do you want continuous integration? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
-    echo '   ↳ To setup Android continuous integration, see README.md.'
+    echo '    ↳ To setup Android continuous integration, see README.md.'
     android_ci_support=1
 fi
 
@@ -68,8 +68,11 @@ WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
 echo "Working directory: $WORKING_DIR"
 trap 'rm -rf "$WORKING_DIR"' EXIT
 curl --progress-bar -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
-unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip" -d "$WORKING_DIR"
+cd $WORKING_DIR || exit
+unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
 cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION" "$project_dir"
+
+cd "$project_dir"
 set +x
 
 # Set up CI support

--- a/generator.sh
+++ b/generator.sh
@@ -64,7 +64,6 @@ git init
 
 # Download the scaffold and copy it into the project directory
 WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
-echo "Working directory: $WORKING_DIR"
 trap 'rm -rf "$WORKING_DIR"' EXIT
 
 curl --progress-bar -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"

--- a/generator.sh
+++ b/generator.sh
@@ -59,11 +59,11 @@ git init
 
 # Download the scaffold and copy it into the project directory
 WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
-print "Working directory: $WORKING_DIR"
+echo "Working directory: $WORKING_DIR"
 trap 'rm -rf "$WORKING_DIR"' EXIT
 curl --progress-bar -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
 unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip" -d "$WORKING_DIR"
-cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION/*" .
+cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION" .
 
 # Set up CI support
 if [[ $ios_ci_support -ne 1 && $android_ci_support -ne 1 ]]; then

--- a/generator.sh
+++ b/generator.sh
@@ -57,6 +57,7 @@ mkdir $project_name
 cd $project_name || exit
 git init
 
+set -x
 # Download the scaffold and copy it into the project directory
 WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
 echo "Working directory: $WORKING_DIR"
@@ -64,6 +65,7 @@ trap 'rm -rf "$WORKING_DIR"' EXIT
 curl --progress-bar -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
 unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip" -d "$WORKING_DIR"
 cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION" .
+set +x
 
 # Set up CI support
 if [[ $ios_ci_support -ne 1 && $android_ci_support -ne 1 ]]; then

--- a/generator.sh
+++ b/generator.sh
@@ -44,19 +44,20 @@ android_ci_support=0
 read -p'--> On iOS, do you want continuous integration? (y/n) ' -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
-    echo 'To setup iOS continuous integration, see README.md.'
+    echo '        ↳ To setup iOS continuous integration, see README.md.'
     ios_ci_support=1
 fi
 
 read -p "--> On Android, do you want continuous integration? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
-    echo 'To setup Android continuous integration, see README.md.'
+    echo '       ↳ To setup Android continuous integration, see README.md.'
     android_ci_support=1
 fi
 
 # Prepare new project directory
 project_dir="$ROOT/$project_name"
+echo "Setting up new project in $project_dir"
 mkdir "$project_dir"
 cd "$project_dir" || exit
 git init

--- a/generator.sh
+++ b/generator.sh
@@ -62,7 +62,7 @@ WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
 trap 'rm -rf "$WORKING_DIR"' EXIT
 curl -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
 unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
-cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION/*" .
+cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION/astro-scaffold-$SCAFFOLD_VERSION/*" .
 
 # Set up CI support
 if [[ $ios_ci_support -ne 1 && $android_ci_support -ne 1 ]]; then

--- a/generator.sh
+++ b/generator.sh
@@ -68,9 +68,12 @@ WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
 echo "Working directory: $WORKING_DIR"
 trap 'rm -rf "$WORKING_DIR"' EXIT
 curl --progress-bar -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
+ls "$WORKING_DIR"
 cd $WORKING_DIR || exit
 unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
+ls "$WORKING_DIR"
 cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION" "$project_dir"
+ls "$project_dir"
 
 cd "$project_dir"
 set +x

--- a/generator.sh
+++ b/generator.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -o pipefail
 
+MYDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOT=$MYDIR
+
 ASTRO_VERSION=0.7.0
 SCAFFOLD_VERSION=$ASTRO_VERSION
 SCAFFOLD_URL="https://github.com/mobify/astro-scaffold/archive/$SCAFFOLD_VERSION.zip"
@@ -53,8 +56,9 @@ if [[ $REPLY =~ ^[Yy]$ ]] ; then
 fi
 
 # Prepare new project directory
-mkdir $project_name
-cd $project_name || exit
+project_dir="$ROOT/$project_name"
+mkdir "$project_dir"
+cd "$project_dir" || exit
 git init
 
 set -x
@@ -64,7 +68,7 @@ echo "Working directory: $WORKING_DIR"
 trap 'rm -rf "$WORKING_DIR"' EXIT
 curl --progress-bar -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
 unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip" -d "$WORKING_DIR"
-cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION" .
+cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION" "$project_dir"
 set +x
 
 # Set up CI support

--- a/generator.sh
+++ b/generator.sh
@@ -60,10 +60,10 @@ git init
 # Download the scaffold and copy it into the project directory
 WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
 print "Working directory: $WORKING_DIR"
-# trap 'rm -rf "$WORKING_DIR"' EXIT
-curl -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
-unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
-cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION/astro-scaffold-$SCAFFOLD_VERSION/*" .
+trap 'rm -rf "$WORKING_DIR"' EXIT
+curl --progress-bar -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
+unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip" -d "$WORKING_DIR"
+cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION/*" .
 
 # Set up CI support
 if [[ $ios_ci_support -ne 1 && $android_ci_support -ne 1 ]]; then

--- a/generator.sh
+++ b/generator.sh
@@ -59,7 +59,8 @@ git init
 
 # Download the scaffold and copy it into the project directory
 WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
-trap 'rm -rf "$WORKING_DIR"' EXIT
+print "Working directory: $WORKING_DIR"
+# trap 'rm -rf "$WORKING_DIR"' EXIT
 curl -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
 unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
 cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION/astro-scaffold-$SCAFFOLD_VERSION/*" .

--- a/generator.sh
+++ b/generator.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -o pipefail
 
+ASTRO_VERSION=0.7.0
+SCAFFOLD_VERSION=$ASTRO_VERSION
+SCAFFOLD_URL="https://github.com/mobify/astro-scaffold/archive/$SCAFFOLD_VERSION.zip"
+
 read -p"--> We have a license you must read and agree to. Read license? (y/n) " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
@@ -48,12 +52,19 @@ if [[ $REPLY =~ ^[Yy]$ ]] ; then
     android_ci_support=1
 fi
 
+# Prepare new project directory
 mkdir $project_name
 cd $project_name || exit
-
 git init
-git pull git@github.com:mobify/astro-scaffold.git 0.7.0 --depth 1
 
+# Download the scaffold and copy it into the project directory
+WORKING_DIR=$(mktemp -d /tmp/astro-scaffold.XXXXX)
+trap 'rm -rf "$WORKING_DIR"' EXIT
+curl -L "$SCAFFOLD_URL" -o "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
+unzip "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION.zip"
+cp -R "$WORKING_DIR/astro-scaffold-$SCAFFOLD_VERSION/*" .
+
+# Set up CI support
 if [[ $ios_ci_support -ne 1 && $android_ci_support -ne 1 ]]; then
     rm -rf circle.yml
     rm -rf circle


### PR DESCRIPTION
Converts the generator to get the scaffold zip using the release instead of `git clone`ing it. 

JIRA: N/A
Linked PRs: N/A
## Changes
- Modified `generator.sh` to download the scaffold release .zip instead of `git clone`ing it
- Unzips the file to a temporary directory and then copies it to the project directory
## How to test-drive this PR
- Run the generator as described in this repo's [README](https://github.com/mobify/generator-astro/blob/develop/README.md).
- Verify the scaffold is created in a directory named after the project name you provide
- Verify the scaffold can be opened for iOS and Android
- Verify the scaffold targets Astro 0.7.0
## Research resources
- _none_
## TODOS:

~~\- [ ] Update documentation in the `dev` folder~~
~~\- [ ] Preview the docs to make sure your changes look good (see [here](https://github.com/mobify/astro#documentation) for instructions on how to preview)~~
~~\- [ ] Deploy the updated docs~~
~~\- [ ] Update the [API feature parity spreadsheet](https://docs.google.com/spreadsheets/d/1bQTjiInDM4A1glbLo_CI3FYx6iW3sfL0ykcz8tVRSkw/edit#gid=0)~~
~~\- [ ] Tests have been written~~
~~\- [ ] Tests are passing on CircleCI~~
~~\- [ ] Change works in both Android and iOS~~
- [x] CHANGELOG.md has been updated

~~\- [ ] Update the scaffold if necessary.~~
~~\- [ ] Sandbox is working. If a new feature was added, it was added to the Sandbox app)~~
