### PR TITLE
HYB 730 - Renaming of Scaffold Project Folders

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -143,9 +143,6 @@ egrep -lR "android:host=\"www.mobify.com\"" . | tr '\n' '\0' | xargs -0 -n1 sed 
 # Replace "scaffold" with $project_name inside of files.
 egrep -lR "scaffold" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/scaffold/$project_name/g" 2>/dev/null
 
-# Update symlink to "scaffold-www" folder in android/assets
-ln -sfn ../../../../../app/"$project_name"-www/ android/"$project_name"/src/main/assets/"$project_name"-www
-
 # Configure the ios layout
 egrep -lR "iosUsingTabLayout = false" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/iosUsingTabLayout = false/iosUsingTabLayout = $ios_tab_layout/g" 2>/dev/null
 


### PR DESCRIPTION
No need to update `app-www` symlink after generating project

JIRA: [**[HYB-730] As an scaffold developer, I want a folder structure which is more resilient during generation**](https://mobify.atlassian.net/browse/HYB-730)
Linked PRs: [**astro-scaffold #85**](https://github.com/mobify/astro-scaffold/pull/85)
## Changes
- Removed script line which updates symlink for `-www` folder
## How to test-drive this PR
- Run generator and see if it works
