### PR TITLE
HYB-695: Deeplinking updates

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -137,8 +137,15 @@ done
 egrep -lR "com\.mobify\.astro" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/com\.mobify\.astro\.\$(PRODUCT_NAME:rfc1034identifier)/$bundle_identifier/g" 2>/dev/null
 egrep -lR "com\.mobify\.astro" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/com\.mobify\.astro\.scaffold/$bundle_identifier/g" 2>/dev/null
 
+# Replace "com.mobify.astro" with $bundle_identifier inside of apple-app-site-association file
+egrep -lR "DEV_TEAM_ID.com.mobify.astro" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/DEV_TEAM_ID.com.mobify.astro/DEV_TEAM_ID.$bundle_identifier/g" 2>/dev/null
+
 # Replace "www.mobify.com" with $hostname inside of the AndroidManifest.
 egrep -lR "android:host=\"www.mobify.com\"" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/android:host=\"www.mobify.com\"/android:host=\"$hostname\"/g" 2>/dev/null
+
+# Replace "www.mobify.com" with $hostname inside of the ios entitlements file.
+egrep -lR "applinks:www.mobify.com" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/applinks:www.mobify.com/applinks:$hostname/g" 2>/dev/null
+
 
 # Replace "scaffold" with $project_name inside of files.
 egrep -lR "scaffold" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/scaffold/$project_name/g" 2>/dev/null


### PR DESCRIPTION
Adding steps to rename items in the apple-app-site-association and scaffold.entitlements files

JIRA: https://mobify.atlassian.net/browse/HYB-695
Linked PRs: https://github.com/mobify/astro-scaffold/pull/89
## Changes
- Add steps to rename items in apple-app-site-association and scaffold.entitlements files
## How to test-drive this PR
- Run the generator and ensure that the entitlements file and association file are updated correctly
## TODOS:
- [ ] Change works in both Android and iOS.
- [ ] CHANGELOG.md has been updated.
- [ ] Scaffold is working. If a new feature was added, it was added to the Scaffold app.
- [ ] Run the generator to make sure it still functions correctly.
- [ ] +1 from an engineer on the Astro team.
- [ ] Both tab layout and drawer layout are fully functional in ios. (Set `iosUsingTabLayout` in `baseConfig`)
