### PR TITLE
HYB-790 generator validate bundle identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## To be released
-
+- Validate bundle identifier
 
 ## v0.10.1
 - Astro updated to support Android Studio 2.0

--- a/generator.sh
+++ b/generator.sh
@@ -65,9 +65,9 @@ while [ -z "$bundle_identifier" ]; do
         fi
     else
         bundle_identifier=''
-        echo '--> Invalid package name'
-        echo '--> The name may contain uppercase or lowercase letters ('A' through 'Z'), numbers, and underscores ('_').'
-        echo '--> However, individual package name parts may only start with letters.'
+        echo '      Invalid package name'
+        echo '      The name may contain uppercase or lowercase letters ('A' through 'Z'), numbers, and underscores ('_').'
+        echo '      However, individual package name parts may only start with letters.'
     fi
 done
 

--- a/generator.sh
+++ b/generator.sh
@@ -48,7 +48,7 @@ fi
 hostname=""
 bundle_identifier=""
 
-bundle_regex="^[a-zA-Z]+(\.?[a-zA-Z]+[0-9a-zA-Z]*)+$"
+bundle_regex="^[a-zA-Z]+(\.?[a-zA-Z]+[0-9a-zA-Z\_]*)+$"
 
 while [ -z "$hostname" ]; do
     read -p'--> On Android, which host would you like to use for deep linking? (eg. www.mobify.com) ' hostname

--- a/generator.sh
+++ b/generator.sh
@@ -48,7 +48,7 @@ fi
 hostname=""
 bundle_identifier=""
 
-bundle_regex="^(\.?[a-zA-Z]+[0-9a-zA-Z]*)+$"
+bundle_regex="^[a-zA-Z]+(\.?[a-zA-Z]+[0-9a-zA-Z]*)+$"
 
 while [ -z "$hostname" ]; do
     read -p'--> On Android, which host would you like to use for deep linking? (eg. www.mobify.com) ' hostname

--- a/generator.sh
+++ b/generator.sh
@@ -65,9 +65,9 @@ while [ -z "$bundle_identifier" ]; do
         fi
     else
         bundle_identifier=''
-        echo 'Invalid package name'
-        echo 'The name may contain uppercase or lowercase letters ('A' through 'Z'), numbers, and underscores ('_').'
-        echo 'However, individual package name parts may only start with letters.'
+        echo '--> Invalid package name'
+        echo '--> The name may contain uppercase or lowercase letters ('A' through 'Z'), numbers, and underscores ('_').'
+        echo '--> However, individual package name parts may only start with letters.'
     fi
 done
 

--- a/generator.sh
+++ b/generator.sh
@@ -48,7 +48,7 @@ fi
 hostname=""
 bundle_identifier=""
 
-bundle_regex="^[a-zA-Z]+(\.?[a-zA-Z]+[0-9a-zA-Z\_]*)+$"
+bundle_regex="^[a-zA-Z]+(\.?[a-zA-Z]+\w*)+$"
 
 while [ -z "$hostname" ]; do
     read -p'--> On Android, which host would you like to use for deep linking? (eg. www.mobify.com) ' hostname

--- a/generator.sh
+++ b/generator.sh
@@ -34,7 +34,7 @@ fi
 
 read -p'--> What is the name of your project? ' project_name
 # $project_name must not contain special characters.
-project_name=$(echo "$project_name" | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
+project_name=$(echo "$project_name" | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]' | tr -d ' ')
 
 read -p"--> Continue with the project name '$project_name'? (y/n) " -n 1 -r
 echo
@@ -48,12 +48,27 @@ fi
 hostname=""
 bundle_identifier=""
 
+bundle_regex="^(\.?[a-zA-Z]+[0-9a-zA-Z]*)+$"
+
 while [ -z "$hostname" ]; do
     read -p'--> On Android, which host would you like to use for deep linking? (eg. www.mobify.com) ' hostname
 done
 
 while [ -z "$bundle_identifier" ]; do
     read -p"--> Which iOS Bundle Identifier and Android Package Name would you like to use? Begin with 'com.mobify.' to use HockeyApp. (eg. com.mobify.app) " bundle_identifier
+
+    if [[ "$bundle_identifier" =~ $bundle_regex ]]; then
+        read -p"--> Continue with the iOS Bundle Identifier and Android Package Name $bundle_identifier? (y/n) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
+            bundle_identifier=''
+        fi
+    else
+        bundle_identifier=''
+        echo 'Invalid package name'
+        echo 'The name may contain uppercase or lowercase letters ('A' through 'Z'), numbers, and underscores ('_').'
+        echo 'However, individual package name parts may only start with letters.'
+    fi
 done
 
 ios_ci_support=0


### PR DESCRIPTION
Validate bundle identifier to prevent crashes when running newly generated Android app. Using [these guidelines](http://developer.android.com/guide/topics/manifest/manifest-element.html#package) to verify the name.

JIRA: **[HYB-790 As an Astro developer, I want the Generator to prevent using dashes in the bundle identifier](https://mobify.atlassian.net/browse/HYB-790)**
Linked PRs: **None**
## Changes
- Validate bundle identifier with regex
- Delete all spaces in project name
## How to test-drive this PR
- Run the generator and try and set the bundle identifier to an invalid name
  - _Examples of **invalid** names are_
    - 1com.mobify.app
    - com.mob-ify.app
    - .com.78.mobify.2
- Alternatively you can play with the regex [here](https://regex101.com/r/hN7cV9/4)
## Research resources
- [Android Manifest Element](http://developer.android.com/guide/topics/manifest/manifest-element.html)
