### PR TITLE
update generator wording and setting for android tab layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Add support for tab navigation on Android
+
 ## v0.10.3
 - Add support for buddybuild
 - Validate bundle identifier

--- a/generator.sh
+++ b/generator.sh
@@ -73,7 +73,7 @@ done
 
 ios_ci_support=0
 android_ci_support=0
-ios_tab_layout="false"
+tab_layout="false"
 buddybuild_support=0
 
 read -p'--> On iOS, do you want continuous integration? (y/n) ' -n 1 -r
@@ -100,10 +100,10 @@ else
     fi
 fi
 
-read -p'--> On iOS, do you want to use a tab layout (otherwise a drawer layout will be setup)? (y/n) ' -n 1 -r
+read -p'--> Do you want to use a tab layout (otherwise a drawer layout will be setup)? (y/n) ' -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
-    ios_tab_layout="true"
+    tab_layout="true"
 fi
 
 # Prepare new project directory
@@ -173,8 +173,8 @@ egrep -lR "android:host=\"www.mobify.com\"" . | tr '\n' '\0' | xargs -0 -n1 sed 
 # Replace "scaffold" with $project_name inside of files.
 egrep -lR "scaffold" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/scaffold/$project_name/g" 2>/dev/null
 
-# Configure the ios layout
-egrep -lR "iosUsingTabLayout = false" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/iosUsingTabLayout = false/iosUsingTabLayout = $ios_tab_layout/g" 2>/dev/null
+# Configure the navigation layout
+egrep -lR "useTabLayout = false" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/useTabLayout = false/useTabLayout = $tab_layout/g" 2>/dev/null
 
 git init
 git add .

--- a/generator.sh
+++ b/generator.sh
@@ -4,7 +4,7 @@ set -o pipefail
 MYDIR=$(pwd)
 ROOT=$MYDIR # In some scripts ROOT != MYDIR
 
-SCAFFOLD_VERSION_OR_BRANCH=0.13.0
+SCAFFOLD_VERSION_OR_BRANCH=master
 SCAFFOLD_URL="https://github.com/mobify/astro-scaffold/archive/$SCAFFOLD_VERSION_OR_BRANCH.zip"
 
 echo '                                '
@@ -22,7 +22,7 @@ if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
     exit 1
 fi
 
-curl -s -O -L https://raw.githubusercontent.com/mobify/generator-astro/develop/LICENSE
+curl -s -O -L https://raw.githubusercontent.com/mobify/generator-astro/master/LICENSE
 trap 'rm -f LICENSE' EXIT
 less LICENSE
 


### PR DESCRIPTION
## Changes
- Make sure generator wording is no longer platform specific for tab layout
## How to test

make sure the `generator.sh` is pointing to the right branch for `astro-scaffold`

```
Line 8:  SCAFFOLD_VERSION_OR_BRANCH=HYB-553-android-tab-navigation
```

Run

```
./generator.sh
```

Check generated project is correct
